### PR TITLE
Limit userId EditText input type to number

### DIFF
--- a/app/src/main/res/layout/activity_auth.xml
+++ b/app/src/main/res/layout/activity_auth.xml
@@ -22,6 +22,7 @@
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         android:hint="User id"
+        android:inputType="number"
         android:textColor="#000"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"


### PR DESCRIPTION
Since the user is expected to enter a number, let's restrict it and make sure there is no crash when user enters text and Integer.parseInt() is successful